### PR TITLE
[danceparty] remove clashing prettier rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,5 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
-  "extends": ["prettier", "plugin:prettier/recommended"]
+  "extends": ["prettier"]
 }

--- a/__tests__/discord-client.test.ts
+++ b/__tests__/discord-client.test.ts
@@ -16,11 +16,6 @@ describe("DiscordClient", () => {
   });
 
   describe("sendMessage()", () => {
-    beforeEach(() => {
-      process.env.CHANGELOG_CHANNEL = "123456789012345678";
-      process.env.CHANNEL = "876543210987654321";
-    });
-
     test("successfully calls channel.send when called correctly", async () => {
       await discordClient.sendMessage(MESSAGES.GOML, DiscordClient.CHANNELS.CHANGELOG);
       expect(discordClient.channels.cache.get).toHaveBeenCalledWith(DiscordClient.CHANNELS.CHANGELOG);

--- a/__tests__/discord-client.test.ts
+++ b/__tests__/discord-client.test.ts
@@ -16,6 +16,13 @@ describe("DiscordClient", () => {
   });
 
   describe("sendMessage()", () => {
+    beforeEach(() => {
+      discordClient.isValidChannel = jest.fn((channelName) => {
+        // mocking environment variables
+        return true;
+      });
+    });
+
     test("successfully calls channel.send when called correctly", async () => {
       await discordClient.sendMessage(MESSAGES.GOML, DiscordClient.CHANNELS.CHANGELOG);
       expect(discordClient.channels.cache.get).toHaveBeenCalledWith(DiscordClient.CHANNELS.CHANGELOG);
@@ -51,7 +58,7 @@ describe("DiscordClient", () => {
 
   describe("isValidChannel", () => {
     test("returns true if the channel is not empty", () => {
-      const input = "channel name";
+      const input = "123456789012345678";
       const output = true;
       expect(discordClient.isValidChannel(input)).toEqual(output);
     });

--- a/__tests__/discord-client.test.ts
+++ b/__tests__/discord-client.test.ts
@@ -17,10 +17,8 @@ describe("DiscordClient", () => {
 
   describe("sendMessage()", () => {
     beforeEach(() => {
-      discordClient.isValidChannel = jest.fn((channelName) => {
-        // mocking environment variables
-        return true;
-      });
+      process.env.CHANGELOG_CHANNEL = "123456789012345678";
+      process.env.CHANNEL = "876543210987654321";
     });
 
     test("successfully calls channel.send when called correctly", async () => {

--- a/config/jest.setup.js
+++ b/config/jest.setup.js
@@ -1,0 +1,8 @@
+module.exports = async () => {
+  const CHANNEL_CHANGELOG = "123456789012345678";
+  const CHANNEL_MAIN = "876543210987654321";
+  process.env = Object.assign(process.env, {
+    CHANGELOG_CHANNEL: CHANNEL_CHANGELOG,
+    CHANNEL: CHANNEL_MAIN,
+  });
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  setupFiles: ["dotenv/config"],
+  globalSetup: "./config/jest.setup.js",
 };

--- a/src/DiscordClient.ts
+++ b/src/DiscordClient.ts
@@ -34,9 +34,8 @@ class DiscordClient extends Client {
   };
 
   isValidChannel = (channelName: string): boolean => {
-    // since they are environment variables, we can only really check that
-    // they are not empty
-    return channelName.length > 0;
+    // channel ids seem to always be 18 length
+    return channelName.length === 18;
   };
 }
 


### PR DESCRIPTION
Needed to re-open this PR from the old repository (https://github.com/awseale/discordBot/pull/16) since this will fix our tests by introducing appropriate environment variables during test runs.