### PR TITLE
Update git repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           username: ${{ secrets.HOST_USERNAME }}
           password: ${{ secrets.HOST_PASSWORD }}
           key: ${{ secrets.SSH_KEY }}
-          script: cd ~/apps/nyt-crossword-discord-bot && git pull git@github.com:awseale/discordBot.git
+          script: cd ~/apps/nyt-crossword-discord-bot && git pull git@github.com:NYTDiscordBot/DiscordBot.git
       - name: Restart App
         uses: appleboy/ssh-action@master
         with:


### PR DESCRIPTION
This _might_ just work on it's own, since the old repo shares the same git history, but it will probably be confusing if we ever have to debug the code on the DO droplet for whatever reason, since the repository that's cloned there currently is from the old repo (https://github.com/awseale/discordBot) and will maintain that as the old .

@awseale or @DanceParty we'll probably want to update the repository's remote URI on the droplet via `git remote set-url origin git@github.com:NYTDiscordBot/DiscordBot.git` and then refresh the history with a `git pull`.