### PR TITLE
Use channel ID when referring to a channel

### DIFF
--- a/__tests__/commands/goml.test.ts
+++ b/__tests__/commands/goml.test.ts
@@ -22,7 +22,7 @@ describe("Goml", () => {
       test("when a 'goml' message was not sent in the 'main' channel.", async () => {
         // I think the fact that I have to define `valueOf` here is a bug
         // or I'm just not understanding something about how `Partial` works here.
-        const channel: Partial<TextChannel> = { name: DiscordClient.CHANNELS.MAIN + "foo", valueOf: () => { return "why"; }};
+        const channel: Partial<TextChannel> = { name: DiscordClient.CHANNEL_IDS.MAIN + "foo", valueOf: () => { return "why"; }};
         await goml(discordClient, <TextChannel>channel);
         expect(sendMock).toBeCalledTimes(0);
       });
@@ -31,7 +31,7 @@ describe("Goml", () => {
     describe("should send a message", () => {
       test("when a 'goml' message was sent in the 'main' channel.", async () => {
         // Again more weirdness with `valueOf` and partial type definition here.
-        const channel: Partial<TextChannel> = { name: DiscordClient.CHANNELS.MAIN, valueOf: () => { return "why"; }};
+        const channel: Partial<TextChannel> = { name: DiscordClient.CHANNEL_IDS.MAIN, valueOf: () => { return "why"; }};
         await goml(discordClient, <TextChannel>channel);
         expect(sendMock).toBeCalledTimes(1);
       })

--- a/__tests__/commands/goml.test.ts
+++ b/__tests__/commands/goml.test.ts
@@ -22,7 +22,7 @@ describe("Goml", () => {
       test("when a 'goml' message was not sent in the 'main' channel.", async () => {
         // I think the fact that I have to define `valueOf` here is a bug
         // or I'm just not understanding something about how `Partial` works here.
-        const channel: Partial<TextChannel> = { name: DiscordClient.CHANNEL_IDS.MAIN + "foo", valueOf: () => { return "why"; }};
+        const channel: Partial<TextChannel> = { id: DiscordClient.CHANNEL_IDS.MAIN + "foo", valueOf: () => { return "why"; }};
         await goml(discordClient, <TextChannel>channel);
         expect(sendMock).toBeCalledTimes(0);
       });
@@ -31,7 +31,7 @@ describe("Goml", () => {
     describe("should send a message", () => {
       test("when a 'goml' message was sent in the 'main' channel.", async () => {
         // Again more weirdness with `valueOf` and partial type definition here.
-        const channel: Partial<TextChannel> = { name: DiscordClient.CHANNEL_IDS.MAIN, valueOf: () => { return "why"; }};
+        const channel: Partial<TextChannel> = { id: DiscordClient.CHANNEL_IDS.MAIN, valueOf: () => { return "why"; }};
         await goml(discordClient, <TextChannel>channel);
         expect(sendMock).toBeCalledTimes(1);
       })

--- a/__tests__/discord-client.test.ts
+++ b/__tests__/discord-client.test.ts
@@ -17,8 +17,8 @@ describe("DiscordClient", () => {
 
   describe("sendMessage()", () => {
     test("successfully calls channel.send when called correctly", async () => {
-      await discordClient.sendMessage(MESSAGES.GOML, DiscordClient.CHANNELS.CHANGELOG);
-      expect(discordClient.channels.cache.get).toHaveBeenCalledWith(DiscordClient.CHANNELS.CHANGELOG);
+      await discordClient.sendMessage(MESSAGES.GOML, DiscordClient.CHANNEL_IDS.CHANGELOG);
+      expect(discordClient.channels.cache.get).toHaveBeenCalledWith(DiscordClient.CHANNEL_IDS.CHANGELOG);
       expect(sendMock).toHaveBeenCalledWith(MESSAGES.GOML);
     });
 

--- a/src/DiscordClient.ts
+++ b/src/DiscordClient.ts
@@ -7,7 +7,7 @@ export enum MESSAGES {
 }
 
 class DiscordClient extends Client {
-  static CHANNELS = {
+  static CHANNEL_IDS = {
     CHANGELOG: process.env.CHANGELOG_CHANNEL || "",
     MAIN: process.env.CHANNEL || "",
   };
@@ -16,14 +16,14 @@ class DiscordClient extends Client {
     super();
   }
 
-  sendMessage = async (message: MESSAGES, channelName: string) => {
+  sendMessage = async (message: MESSAGES, channelId: string) => {
     const hasValidChannels =
-      this.isValidChannel(DiscordClient.CHANNELS.CHANGELOG) && this.isValidChannel(DiscordClient.CHANNELS.MAIN);
-    const channelNameMatches =
-      channelName === DiscordClient.CHANNELS.CHANGELOG || channelName === DiscordClient.CHANNELS.MAIN;
+      this.isValidChannel(DiscordClient.CHANNEL_IDS.CHANGELOG) && this.isValidChannel(DiscordClient.CHANNEL_IDS.MAIN);
+    const channelIdMatches =
+      channelId === DiscordClient.CHANNEL_IDS.CHANGELOG || channelId === DiscordClient.CHANNEL_IDS.MAIN;
     if (hasValidChannels) {
-      if (channelNameMatches) {
-        const channel = await this.channels.fetch(channelName);
+      if (channelIdMatches) {
+        const channel = await this.channels.fetch(channelId);
         (channel as TextChannel)?.send(message);
       }
     }
@@ -33,9 +33,9 @@ class DiscordClient extends Client {
     return message.toLowerCase().trim();
   };
 
-  isValidChannel = (channelName: string): boolean => {
+  isValidChannel = (channelId: string): boolean => {
     // channel ids seem to always be 18 length
-    return channelName.length === 18;
+    return channelId.length === 18;
   };
 }
 

--- a/src/NYTCrosswordPuzzleBot.ts
+++ b/src/NYTCrosswordPuzzleBot.ts
@@ -11,15 +11,15 @@ discordClient.login(process.env.TOKEN || "");
 
 discordClient.on("ready", async () => {
   console.log("eggy kibun");
-  await discordClient.sendMessage(MESSAGES.UPDATE, DiscordClient.CHANNELS.CHANGELOG);
+  await discordClient.sendMessage(MESSAGES.UPDATE, DiscordClient.CHANNEL_IDS.CHANGELOG);
 
   //NYT Crossword updates at 10PM EST on weekdays and 6PM EST on weekends
   Cron.startJob(CRON_INTERVALS.WEEKDAY, async () => {
-    await discordClient.sendMessage(MESSAGES.PUZZLE, DiscordClient.CHANNELS.MAIN);
+    await discordClient.sendMessage(MESSAGES.PUZZLE, DiscordClient.CHANNEL_IDS.MAIN);
   });
 
   Cron.startJob(CRON_INTERVALS.WEEKEND, async () => {
-    await discordClient.sendMessage(MESSAGES.PUZZLE, DiscordClient.CHANNELS.MAIN);
+    await discordClient.sendMessage(MESSAGES.PUZZLE, DiscordClient.CHANNEL_IDS.MAIN);
   });
 });
 

--- a/src/commands/Goml.ts
+++ b/src/commands/Goml.ts
@@ -2,7 +2,7 @@ import { DMChannel, NewsChannel, TextChannel } from "discord.js";
 import DiscordClient, { MESSAGES } from "../DiscordClient";
 
 async function goml(client: DiscordClient, channel: DMChannel | TextChannel | NewsChannel): Promise<void> {
-  if (channel instanceof DMChannel || channel.name !== DiscordClient.CHANNELS.MAIN) return;
+  if (channel instanceof DMChannel || channel.id !== DiscordClient.CHANNEL_IDS.MAIN) return;
 
   await client.sendMessage(MESSAGES.GOML, DiscordClient.CHANNEL_IDS.MAIN);
 }

--- a/src/commands/Goml.ts
+++ b/src/commands/Goml.ts
@@ -4,7 +4,7 @@ import DiscordClient, { MESSAGES } from "../DiscordClient";
 async function goml(client: DiscordClient, channel: DMChannel | TextChannel | NewsChannel): Promise<void> {
   if (channel instanceof DMChannel || channel.name !== DiscordClient.CHANNELS.MAIN) return;
 
-  await client.sendMessage(MESSAGES.GOML, channel.name);
+  await client.sendMessage(MESSAGES.GOML, DiscordClient.CHANNEL_IDS.MAIN);
 }
 
 export default goml;


### PR DESCRIPTION
[`ChannelManager#fetch` fetches by channel ID and not by channel name](https://discord.js.org/#/docs/main/v12/class/ChannelManager?scrollTo=fetch).